### PR TITLE
⚡️ Implement `httpx` (over `requests`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,3 @@ Only the core, unauthenticated endpoints are currently implemented. However, bet
 ## What about Authentication?
 The InnerTube API uses OAuth2, however I have been unable to successfully implement authentication.
 Therefore, this library currently only provides unauthenticated access to the API.
-
-## Credits
-Here's a list of the awesome libraries that helped make `innertube`
-| PyPi | Source |
-| ---- | ------ |
-| [requests](https://pypi.org/project/requests/) | https://github.com/psf/requests |
-| [pydantic](https://pypi.org/project/pydantic/) | https://github.com/samuelcolvin/pydantic |
-| [addict](https://pypi.org/project/addict/) | https://github.com/mewwts/addict |
-| [attrs](https://pypi.org/project/attrs/) | https://github.com/python-attrs/attrs |
-| [furl](https://pypi.org/project/furl/) | https://github.com/gruns/furl |
-| [humps](https://pypi.org/project/pyhumps/) | https://github.com/nficano/humps |
-| [parse](https://pypi.org/project/parse/) | https://github.com/r1chardj0n3s/parse |

--- a/innertube/apis.py
+++ b/innertube/apis.py
@@ -27,7 +27,7 @@ class InnerTube(clients.InnerTubeClient):
         )
 
         self.session.headers.update(adaptor.headers)
-        self.session.params.update(adaptor.params)
+        self.session.params = self.session.params.merge(adaptor.params)
         self.session.context.update(adaptor.context)
 
     @property

--- a/innertube/clients.py
+++ b/innertube/clients.py
@@ -1,16 +1,12 @@
-import attr
-import addict
-import requests
-
-import roster
-
 import abc
 import typing
 
-from . import sessions
-from . import utils
-from . import models
-from . import errors
+import addict
+import attr
+import httpx
+import roster
+
+from . import errors, models, sessions, utils
 
 attrs = attr.s(
     auto_detect=True,
@@ -53,11 +49,13 @@ class BaseInnerTubeClient(BaseClient):
             return data
 
     def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> addict.Dict:
-        response: requests.Response = self.session.post(*args, **kwargs)
+        response: httpx.Response = self.session.post(*args, **kwargs)
 
         response_data: addict.Dict = addict.Dict(response.json())
 
-        fingerprint: models.ResponseFingerprint = models.ResponseFingerprint.from_response(response)
+        fingerprint: models.ResponseFingerprint = (
+            models.ResponseFingerprint.from_response(response)
+        )
 
         parser: models.Parser = models.Parser.from_model(fingerprint)
 

--- a/innertube/sessions.py
+++ b/innertube/sessions.py
@@ -1,49 +1,24 @@
-import attr
-import addict
-import requests
+from typing import Any, Optional, Union
 
+import addict
+import httpx
 import mediatype
 
-import typing
-import urllib.parse
-
-from . import enums
-from . import models
-from . import infos
-from . import errors
-
-attrs = attr.s(
-    auto_detect=True,
-    auto_attribs=True,
-)
+from . import enums, errors, infos, models
 
 
-@attrs
-class BaseSession(requests.Session):
-    def __attrs_pre_init__(self) -> None:
-        super().__init__()
+class BaseSession(httpx.Client):
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(base_url={str(self.base_url)!r})"
 
 
-@attrs
-class BaseUrlSession(BaseSession):
-    base_url: typing.Optional[str] = attr.ib(
-        default=None,
-        init=False,
-    )
+class JSONSession(BaseSession):
+    def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+        response: httpx.Response = super().send(request, **kwargs)
 
-    def prepare_request(self, request: requests.Request) -> requests.PreparedRequest:
-        if self.base_url is not None:
-            request.url = urllib.parse.urljoin(self.base_url, request.url)
-
-        return super().prepare_request(request)
-
-
-@attrs
-class JSONSession(BaseUrlSession):
-    def send(self, request: requests.Request, **kwargs: typing.Any) -> requests.Response:
-        response: requests.Response = super().send(request, **kwargs)
-
-        content_type: mediatype.MediaType = mediatype.parse(response.headers.get(str(enums.Header.CONTENT_TYPE)))
+        content_type: mediatype.MediaType = mediatype.parse(
+            response.headers.get(str(enums.Header.CONTENT_TYPE))
+        )
 
         if content_type.subtype != mediatype.MediaTypeSubtype.JSON:
             if not response.ok:
@@ -65,28 +40,33 @@ class JSONSession(BaseUrlSession):
         return response
 
 
-@attrs
 class InnerTubeSession(JSONSession):
-    base_url: str = attr.ib(
-        default=str(infos.apis[enums.Host.YOUTUBEI]),
-        init=False,
-    )
+    context: dict
 
-    context: dict = attr.ib(
-        default=attr.Factory(dict),
-        init=False,
-    )
+    def __init__(
+        self,
+        *args,
+        base_url: str = str(infos.apis[enums.Host.YOUTUBEI]),
+        context: Optional[dict] = None,
+        **kwargs,
+    ):
+        super().__init__(*args, base_url=base_url, **kwargs)
 
-    def prepare_request(self, request: requests.Request) -> requests.PreparedRequest:
-        if request.method == enums.Method.POST and self.context:
-            request.json = addict.Dict(request.json or {})
+        self.context = context or {}
 
-            request.json.context.client.update(self.context)
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(base_url={str(self.base_url)!r}, context={self.context})"
 
-        return super().prepare_request(request)
+    def build_request(self, method: str, *args, json: Any = None, **kwargs):
+        if method == enums.Method.POST and self.context:
+            json = addict.Dict(json or {})
 
-    def send(self, request: requests.Request, **kwargs: typing.Any) -> requests.Response:
-        response: requests.Response = super().send(request, **kwargs)
+            json.context.client.update(self.context)
+
+        return super().build_request(method, *args, json=json, **kwargs)
+
+    def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+        response: httpx.Response = super().send(request, **kwargs)
 
         response_data: addict.Dict = addict.Dict(response.json())
 
@@ -94,7 +74,7 @@ class InnerTubeSession(JSONSession):
         if error := response_data.error:
             raise errors.RequestError(models.Error.parse_obj(error))
 
-        visitor_data: typing.Union[addict.Dict, str]
+        visitor_data: Union[addict.Dict, str]
         if visitor_data := response_data.responseContext.visitorData:
             self.headers[str(enums.GoogleHeader.VISITOR_ID)] = visitor_data
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,23 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "anyio"
+version = "3.5.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+
+[package.extras]
+doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -127,6 +144,53 @@ python-versions = "*"
 [package.dependencies]
 orderedmultidict = ">=1.0.1"
 six = ">=1.8.0"
+
+[[package]]
+name = "h11"
+version = "0.12.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "httpcore"
+version = "0.14.7"
+description = "A minimal low-level HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+anyio = ">=3.0.0,<4.0.0"
+certifi = "*"
+h11 = ">=0.11,<0.13"
+sniffio = ">=1.0.0,<2.0.0"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.22.0"
+description = "The next generation HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+certifi = "*"
+charset-normalizer = "*"
+httpcore = ">=0.14.5,<0.15.0"
+rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotlicffi", "brotli"]
+cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10.0.0,<11.0.0)", "pygments (>=2.0.0,<3.0.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "idna"
@@ -299,22 +363,18 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
-name = "requests"
-version = "2.27.1"
-description = "Python HTTP for Humans."
+name = "rfc3986"
+version = "1.5.0"
+description = "Validating URI References per RFC 3986"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "*"
 
 [package.dependencies]
-certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
-urllib3 = ">=1.21.1,<1.27"
+idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+idna2008 = ["idna"]
 
 [[package]]
 name = "roster"
@@ -331,6 +391,14 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "soset"
@@ -370,28 +438,19 @@ python-versions = ">=3.8,<4.0"
 [package.dependencies]
 parse = ">=1.19.0,<2.0.0"
 
-[[package]]
-name = "urllib3"
-version = "1.26.9"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-
-[package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "4e09bf942518c6d84f219c10c58d636175525ffe8ac26e4b62e61a077e3b0eaa"
+content-hash = "545b3b954456ca98bb8128a6ad1a72a4c06568470aadf8ae32de74f608890698"
 
 [metadata.files]
 addict = [
     {file = "addict-2.4.0-py3-none-any.whl", hash = "sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc"},
     {file = "addict-2.4.0.tar.gz", hash = "sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494"},
+]
+anyio = [
+    {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
+    {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -457,6 +516,18 @@ expo = [
 furl = [
     {file = "furl-2.1.3-py2.py3-none-any.whl", hash = "sha256:9ab425062c4217f9802508e45feb4a83e54324273ac4b202f1850363309666c0"},
     {file = "furl-2.1.3.tar.gz", hash = "sha256:5a6188fe2666c484a12159c18be97a1977a71d632ef5bb867ef15f54af39cc4e"},
+]
+h11 = [
+    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
+    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
+]
+httpcore = [
+    {file = "httpcore-0.14.7-py3-none-any.whl", hash = "sha256:47d772f754359e56dd9d892d9593b6f9870a37aeb8ba51e9a88b09b3d68cfade"},
+    {file = "httpcore-0.14.7.tar.gz", hash = "sha256:7503ec1c0f559066e7e39bc4003fd2ce023d01cf51793e3c173b864eb456ead1"},
+]
+httpx = [
+    {file = "httpx-0.22.0-py3-none-any.whl", hash = "sha256:e35e83d1d2b9b2a609ef367cc4c1e66fd80b750348b20cc9e19d1952fc2ca3f6"},
+    {file = "httpx-0.22.0.tar.gz", hash = "sha256:d8e778f76d9bbd46af49e7f062467e3157a5a3d2ae4876a4bbfd8a51ed9c9cb4"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -571,9 +642,9 @@ pytest = [
     {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
     {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
 ]
-requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+rfc3986 = [
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 roster = [
     {file = "roster-0.1.8-py3-none-any.whl", hash = "sha256:1996902111671440965a0031a8e4e1e55adf8f40d07836da10a66554584ba763"},
@@ -582,6 +653,10 @@ roster = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
 ]
 soset = [
     {file = "soset-0.1.1-py3-none-any.whl", hash = "sha256:2421fceb1de6f6a7454340f1c0a0dcfbe541a4b5381d2c3f7baa12b0c1863b0a"},
@@ -598,8 +673,4 @@ typing-extensions = [
 ua = [
     {file = "ua-0.1.5-py3-none-any.whl", hash = "sha256:2d67cf3a8f63e62f34b912d456d27fbfaa691b3ec34fab78da66ce9050b9ca4e"},
     {file = "ua-0.1.5.tar.gz", hash = "sha256:01bda1d1ae3b9c90e693bb18fb72c8a513aff5c7c9009f03b5a997512beaae62"},
-]
-urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "innertube"
-version = "1.0.13"
+version = "1.0.14"
 description = "Python Client for Google's Private InnerTube API. Works with Youtube, YouTubeMusic etc."
 authors = ["Tom Bulled <26026015+tombulled@users.noreply.github.com>"]
 license = "MIT"
@@ -12,7 +12,6 @@ keywords = ["youtube", "innertube", "python", "api"]
 [tool.poetry.dependencies]
 python = "^3.8"
 pydantic = "^1.7.3"
-requests = "^2.25.1"
 addict = "^2.4.0"
 furl = "^2.1.0"
 parse = "^1.19.0"
@@ -22,6 +21,8 @@ enumb = "^0.1.5"
 mediatype = "^0.1.6"
 ua = "^0.1.5"
 roster = "^0.1.8"
+httpx = "^0.22.0"
+typing-extensions = "^4.1.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"


### PR DESCRIPTION
As `httpx` has better support for a `base_url` and asynchronous requests, this PR implements `httpx` over `requests`. As `httpx` has been designed as a drop-in replacement, compatibility should remain largely unaffected.