### PR TITLE
:bug: InnerTube.browse(): Specify `continuation` in request body

### DIFF
--- a/innertube/clients.py
+++ b/innertube/clients.py
@@ -106,16 +106,11 @@ class InnerTube(Client):
     ) -> dict:
         return self(
             Endpoint.BROWSE,
-            params=utils.filter(
-                dict(
-                    continuation=continuation,
-                    ctoken=continuation,
-                )
-            ),
             body=utils.filter(
                 dict(
                     browseId=browse_id,
                     params=params,
+                    continuation=continuation,
                 )
             ),
         )


### PR DESCRIPTION
In newer client versions the `continuation` is specified in the request body, rather than as query params