### PR TITLE
🐛 InnerTube.browse(): Specify continuation in request body for search method

### DIFF
--- a/innertube/clients.py
+++ b/innertube/clients.py
@@ -124,16 +124,11 @@ class InnerTube(Client):
     ) -> dict:
         return self(
             Endpoint.SEARCH,
-            params=utils.filter(
-                dict(
-                    continuation=continuation,
-                    ctoken=continuation,
-                )
-            ),
             body=utils.filter(
                 dict(
                     query=query or "",
                     params=params,
+                    continuation=continuation,
                 )
             ),
         )


### PR DESCRIPTION
In newer client versions the `continuation` is specified in the request body, rather than as query params